### PR TITLE
set up github action for CI build and codecov

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -1,0 +1,28 @@
+# This is a basic workflow to help you get started with Actions
+
+name: Codecov
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the master branch
+on:
+  push:
+  pull_request:
+
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+    - uses: actions/checkout@v2
+
+    - name: Run cobertura
+      run: mvn cobertura:cobertura
+
+    - name: Upload report
+      run: bash <(curl -s https://codecov.io/bash)

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,0 +1,31 @@
+# This workflow will build a Java project with Maven
+# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
+
+name: Build
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        java: [7, 8, 9.0.x, 10, 11, 12, 13]
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up JDK
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{ matrix.java }}
+
+      - name: Clean Build
+        run: mvn clean
+
+      - name: Build with Maven
+        run: mvn -B package --file pom.xml

--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@ java-xmlbuilder
 
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.jamesmurty.utils/java-xmlbuilder/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.jamesmurty.utils/java-xmlbuilder)
 
+![Build](https://github.com/jmurty/java-xmlbuilder/workflows/Build/badge.svg) ![Codecov](https://github.com/jmurty/java-xmlbuilder/workflows/Codecov/badge.svg)
+
+[![codecov](https://codecov.io/gh/jmurty/java-xmlbuilder/branch/master/graph/badge.svg)](https://codecov.io/gh/jmurty/java-xmlbuilder)
+
 XML Builder is a utility that allows simple XML documents to be constructed
 using relatively sparse Java code.
 

--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,19 @@
           </execution>
         </executions>
       </plugin>
-      
+
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>cobertura-maven-plugin</artifactId>
+        <version>2.7</version>
+        <configuration>
+          <formats>
+            <format>html</format>
+            <format>xml</format>
+          </formats>
+          <check />
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION
fix #18 

1. set up github action for CI build and codecov
2. add build and codecov badge in README.md

BTW, @jmurty I need you to set up codecov for java-xmlbuilder here (Just auth codecov.io to read the repo) :
[https://codecov.io/gh/jmurty/java-xmlbuilder/](https://codecov.io/gh/jmurty/java-xmlbuilder/)